### PR TITLE
fixing stuff after forum report

### DIFF
--- a/usr/share/openmediavault/mkconf/flashmemory
+++ b/usr/share/openmediavault/mkconf/flashmemory
@@ -35,7 +35,7 @@ fi
 cat <<EOF > ${FS2RAM_CONFIG}
 # this file was automatically generated
 #<file system>  <mount point>               <script>                <script option> <type>  <options>
-tmpfs           /var/cache                  keep_folder_structure   -               tmpfs
+tmpfs           /var/cache                  keep_file_content       -               tmpfs
 tmpfs           /var/log                    keep_file_structure     -               tmpfs
 tmpfs           /var/tmp                    -                       -               tmpfs
 tmpfs           /var/lib/openmediavault/rrd keep_file_content       -               tmpfs
@@ -45,7 +45,8 @@ tmpfs           /var/lib/monit              keep_file_content       -           
 tmpfs           /var/lib/php5               keep_folder_structure   -               tmpfs
 EOF
 
-# link mounts to mtab
-ln -sf /proc/mounts /etc/mtab
+#disabling apt disk cache so its folder in /var/cache/apt/whatever won't ever fill up. Also saves additional writes.
+echo Dir::Cache ""; >> /etc/apt/apt.conf.d/02nocache 
+echo Dir::Cache::archives ""; >> /etc/apt/apt.conf.d/02nocache
 
 exit 0


### PR DESCRIPTION
var/cache is better kept as "keep file content" because omv seems to like doing stuff with it.
Since the only thing that can realistically fill it up is apt's package cache, and you don't seem to like running chronjobs to clean it regularly, I suggest to add a setting file to apt to disable it as explained here http://ask.xmodulo.com/disable-apt-cache-debian-ubuntu.html

Also, the mtab symlinking seems unnecessary, it seems like Debian adopted this symlink as a standard somewhere in 2012, so in wheezy it comes as standard. I did follow older guides, updated the tutorial though.
