### PR TITLE
changing cron-apt options

### DIFF
--- a/usr/share/openmediavault/mkconf/flashmemory
+++ b/usr/share/openmediavault/mkconf/flashmemory
@@ -49,12 +49,14 @@ EOF
 echo 
 '#!/bin/bash
 #waiting for the package manager to finish its job.
-    while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1; do
+    while [[ ! -f /var/lib/dpkg/lock ]]; do
     sleep 1
     done
 #disabling apt disk cache so its folder in /var/cache/apt/whatever will stop filling up. Also saves additional writes.
     echo Dir::Cache ""; >> /etc/apt/apt.conf.d/02nocache 
     echo Dir::Cache::archives ""; >> /etc/apt/apt.conf.d/02nocache
+#disabling cron-apt package download by erasing the file asking for it.
+    rm /etc/cron-apt/action.d/3-download
 #deleting the packages already in the cache, because otherwise this is all wasted space in the tmpfs 
 #and time wasted on startup and shutdown as all this stuff is compressed/extracted, especially for devices with weak processors
     rm /var/cache/apt/archives/*


### PR DESCRIPTION
I doubt that anyone will complain for update speed.
Had a look at what chron-apt is doing.
It's standard config. as here http://www.the-art-of-web.com/system/cron-apt-wheezy/
refreshing lists is ok (it's all in ram), asking it to download packages is nonsense as package cache is disabled. For the sake of safety I'm erasing the (modular) config that asks the package download.
Also using a simpler waiting cycle.

I'm wondering, if this plugin is removed, it would be a good idea to reverse these two settings.
Where can I write the script run when uninstalling?

After there is an uninstall script I'd say you can make a new version of the plugin.
