### PR TITLE
adapted config file to deal with folder2ram config parsing change

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+openmediavault-flashmemory (4.2) stable; urgency=low
+
+  * adapted config file to deal with folder2ram config parsing change 
+    (now paths with spaces are suppported)
+
+ -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Sat, 04 Sep 2018 15:20:02 +0200
+
 openmediavault-flashmemory (4.1) stable; urgency=low
 
   * remove enable

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Architecture: all
 Provides: fs2ram
 Conflicts: fs2ram
 Replaces: fs2ram
-Depends: folder2ram (>= 0.2.4),
+Depends: folder2ram (>= 0.2.9),
          openmediavault (>= 3.0.40),
          ${misc:Depends}
 Description: folder2ram plugin for OpenMediaVault

--- a/usr/share/openmediavault/mkconf/flashmemory
+++ b/usr/share/openmediavault/mkconf/flashmemory
@@ -44,16 +44,16 @@ cat > ${FOLDER2RAM_CONFIG} <<'EOF'
 #OPTIONS: does nothing, will be implemented in the future.
 #
 #<file system>  <mount point>                 <options>
-#tmpfs           /var/cache                 #this folder will be activated later after testing is completed
-tmpfs           /var/log
-tmpfs           /var/tmp
-tmpfs           /var/lib/openmediavault/rrd
-tmpfs           /var/spool
-tmpfs           /var/lib/rrdcached/
-tmpfs           /var/lib/monit
-tmpfs           /var/lib/php                #keep_folder_structure   folder2ram does not have an equivalent yet
-tmpfs           /var/lib/netatalk/CNID
-tmpfs           /var/cache/samba
+#tmpfs      /var/cache      #this folder will be activated later after testing is completed
+tmpfs       /var/log
+tmpfs       /var/tmp
+tmpfs       /var/lib/openmediavault/rrd
+tmpfs       /var/spool
+tmpfs       /var/lib/rrdcached/
+tmpfs       /var/lib/monit
+tmpfs       /var/lib/php        #keep_folder_structure   folder2ram does not have an equivalent yet
+tmpfs       /var/lib/netatalk/CNID
+tmpfs       /var/cache/samba
 EOF
 
 #disabling cron-apt package download by erasing the file asking for it.


### PR DESCRIPTION
    (now paths with spaces are suppported)

bumped the minimum folder2ram version required for this

@ryecoaaron folder2ram from 0.2.9 onwards will not be able to read config files with spaces separating the type from the mountpoint, so if you just update the package the current configs will break.

If you think it's necessary I can write some shell script that converts old configurations into the new type, that can be added in the pre-installation scripts.

The main difference is that by using tabs instead of spaces it can read paths with spaces without issues, if you don't think it's worth the effort to migrate stuff you can just not update to 0.2.9 and it will still be fine.