### PR TITLE
Make settings page more beginner friendly

### DIFF
--- a/var/www/openmediavault/js/omv/module/admin/storage/flashmemory/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/storage/flashmemory/Settings.js
@@ -47,15 +47,22 @@ Ext.define("OMV.module.admin.storage.flashmemory.Settings", {
             },{
                 xtype: "textfield",
                 name: "root",
-                fieldLabel: _("System location"),
+                fieldLabel: _("System drive"),
                 submitValue: false,
-                readOnly: true
+                readOnly: true,
+                plugins: [{
+                    ptype: "fieldinfo",
+                    text: _("Location of the OMV root file system")
             },{
                 xtype: "textfield",
                 name: "written",
-                fieldLabel: _("Writes since last boot [kB]"),
+                fieldLabel: _("Writes"),
                 submitValue: false,
-                readOnly: true
+                readOnly: true,
+                plugins: [{
+                    ptype: "fieldinfo",
+                    text: _("Amount of data (in kB), that got written to the system drive since last boot")
+                }]
             }]
         },{
             xtype: "fieldset",
@@ -67,7 +74,7 @@ Ext.define("OMV.module.admin.storage.flashmemory.Settings", {
                 border: false,
                 html: "<p>" +
                          _("<b>The following instructions are for advanced users only!  Make sure to have sufficient RAM installed for your use case.</b>") +
-                         _("<b>Be aware, that disabling and removing the swap partition only slightly decreases writes, but can lead to issues and system freezes</b>.") +
+                         _("<b>Be aware, that disabling and removing the swap partition only slightly decreases writes, but can lead to issues, warnings and system freezes</b>.") +
                          _("Fstab (/etc/fstab) needs to be changed manually. Follow these steps:") +
                          "<ol>" +
                            "<li>" + _("Login as root locally or via ssh") + "</li>" +

--- a/var/www/openmediavault/js/omv/module/admin/storage/flashmemory/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/storage/flashmemory/Settings.js
@@ -35,34 +35,39 @@ Ext.define("OMV.module.admin.storage.flashmemory.Settings", {
     getFormItems: function() {
         return [{
             xtype: "fieldset",
-            title: "Information",
-            defaults: {
-                labelSeparator: ""
-            },
-            items: [{
-                xtype: "textfield",
-                name: "root",
-                fieldLabel: _("OMV Root"),
-                submitValue: false,
-                readOnly: true
-            },{
-                xtype: "textfield",
-                name: "written",
-                fieldLabel: _("Written kB since boot"),
-                submitValue: false,
-                readOnly: true
-            }]
-        },{
-            xtype: "fieldset",
-            title: _("Notes"),
+            title: _("Information"),
             fieldDefaults: {
                 labelSeparator: ""
             },
             items: [{
                 border: false,
                 html: "<p>" +
-                         _("<b>The Flash Memory plugin works out of the box and moves most writes to the RAM without any further configuration needed.</b>") +
-                         _("<b>Therefore the following instructions are 100% optional!  However, they allow to decrease the writes slightly more by disabling and removing the swap partition - recommended for advanced users only, and with a decent amount of RAM installed.</b>") +
+                         _("<b>The Flash Memory plugin is automatically enabled after installation and moves most writes to the RAM without any further configuration.</b>") +
+                      "</p>"
+            },{
+                xtype: "textfield",
+                name: "root",
+                fieldLabel: _("System location"),
+                submitValue: false,
+                readOnly: true
+            },{
+                xtype: "textfield",
+                name: "written",
+                fieldLabel: _("Writes since last boot [kB]"),
+                submitValue: false,
+                readOnly: true
+            }]
+        },{
+            xtype: "fieldset",
+            title: _("Optional settings"),
+            fieldDefaults: {
+                labelSeparator: ""
+            },
+            items: [{
+                border: false,
+                html: "<p>" +
+                         _("<b>The following instructions are for advanced users only!  Make sure to have sufficient RAM installed for your use case.</b>") +
+                         _("<b>Be aware, that disabling and removing the swap partition only slightly decreases writes, but can lead to issues and system freezes</b>.") +
                          _("Fstab (/etc/fstab) needs to be changed manually. Follow these steps:") +
                          "<ol>" +
                            "<li>" + _("Login as root locally or via ssh") + "</li>" +

--- a/var/www/openmediavault/js/omv/module/admin/storage/flashmemory/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/storage/flashmemory/Settings.js
@@ -35,32 +35,35 @@ Ext.define("OMV.module.admin.storage.flashmemory.Settings", {
     getFormItems: function() {
         return [{
             xtype: "fieldset",
-            title: "Details",
+            title: "Information",
             defaults: {
                 labelSeparator: ""
             },
             items: [{
                 xtype: "textfield",
                 name: "root",
-                fieldLabel: _("Root"),
+                fieldLabel: _("OMV Root"),
                 submitValue: false,
                 readOnly: true
             },{
                 xtype: "textfield",
                 name: "written",
-                fieldLabel: _("Write Kbytes"),
+                fieldLabel: _("Written kB since boot"),
                 submitValue: false,
                 readOnly: true
             }]
         },{
             xtype: "fieldset",
-            title: _("Notes (optional)"),
+            title: _("Notes"),
             fieldDefaults: {
                 labelSeparator: ""
             },
             items: [{
                 border: false,
-                html: "<p>" + _("Fstab (/etc/fstab) needs to be changed manually. Following these steps to change:") +
+                html: "<p>" +
+                         _("<b>The Flash Memory plugin works out of the box and moves most writes to the RAM without any further configuration needed.</b>") +
+                         _("<b>Therefore the following instructions are 100% optional!  However, they allow to decrease the writes slightly more by disabling and removing the swap partition - recommended for advanced users only, and with a decent amount of RAM installed.</b>") +
+                         _("Fstab (/etc/fstab) needs to be changed manually. Follow these steps:") +
                          "<ol>" +
                            "<li>" + _("Login as root locally or via ssh") + "</li>" +
                            "<li>" + _("Execute the following command:  <b>nano /etc/fstab</b>") + "</li>" +


### PR DESCRIPTION
This is a first draft on reordering the plugin settings page slightly and make it more self-explanatory with some basic hints and explanations to avoid questions and clarify functionality. I didn't alter the optional instructions yet.

I hope the content itself is correct, but I'm sure the wording and terminology is not ideal.
Also the code might not be 100% right.

Ideas:
- Is there an easy way for users to verify that the plugins works correctly?
- Include a hint about initramfs warnings and increased boot time after following the optional instructions?
- Are there some reliable instructions in e.g. the forums that can be linked to (regarding swap warnings on boot for example)?
- Not sure... throwing ideas. But in theory the "optional settings" instructions can get removed altogether if the benefit is marginal (one forum post gave that impression) and it's considered advanced anyway. Experienced users know how to do it, or find the information. That way you don't need to worry about keeping them up to date at all. Maybe post in the forums once and people can update them if needed. The text could just say:
> Advanced users can remove the swap partition as well to slighly decrease writes even more, but be aware that this can lead to issues, warnings and system freezes. Make sure to have sufficient RAM installed for your use case!
(+ maybe link to the forum post)

Please give some feedback @ryecoaaron! :)