### PR TITLE
turn salt color off during install

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -10,7 +10,7 @@ case "$1" in
         # Activate package triggers
         dpkg-trigger update-workbench
 
-        omv-salt deploy run flashmemory
+        omv-salt deploy run --no-color flashmemory
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
Same issue as https://github.com/OpenMediaVault-Plugin-Developers/openmediavault-omvextrasorg/issues/50 and https://github.com/OpenMediaVault-Plugin-Developers/openmediavault-fail2ban/issues/28.
This time I tried to provide a fix instead of nagging 😉